### PR TITLE
Update alfaview-php-sdk and check API connection on settings page

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -37,7 +37,6 @@ require_once($CFG->dirroot . '/mod/alfaview/vendor/autoload.php');
 class mod_alfaview_api
 {
     private $av;
-    private $apiHost;
     private $apiClientId;
     private $apiCode;
     private $apiCompanyId;
@@ -48,14 +47,12 @@ class mod_alfaview_api
     {
         $config = get_config('mod_alfaview');
 
-        $this->apiHost = $config->api_host;
         $this->apiClientId = $config->api_client_id;
         $this->apiCode = $config->api_code;
         $this->apiCompanyId = $config->api_company_id;
         $this->apiGuestCode = $config->api_guest_code;
 
         $this->av = new Alfaview();
-        $this->av->setHost($this->apiHost);
     }
 
     public function authenticate()

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         }
     },
     "require": {
-        "alfatraining/alfaview-php-sdk": "~2.0"
+        "alfatraining/alfaview-php-sdk": "2.1.0"
     }
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -46,5 +46,8 @@ function xmldb_alfaview_upgrade($oldversion)
     // Documentation for the XMLDB Editor can be found at:
     // https://docs.moodle.org/dev/XMLDB_editor
 
+    if ($oldversion <= 2020063000) {
+        unset_config('api_host', 'mod_alfaview');
+    }
     return true;
 }

--- a/lang/de/alfaview.php
+++ b/lang/de/alfaview.php
@@ -31,14 +31,14 @@ $string['pluginname'] = 'alfaview';
 $string['settings'] = 'Konfiguration';
 $string['settings_desc'] = 'alfaview konfigurieren';
 $string['api_description'] = 'API-Informationen finden Sie in der Administrationsoberfläche unter <a href="https://app.alfaview.com/#/settings/api-keys" target="_blank">Kontoverwaltung</a>.';
-$string['api_host'] = 'Host';
-$string['api_host_desc'] = 'Die URL der alfaview API.';
 $string['api_client_id'] = 'Alias (Client ID)';
 $string['api_client_id_desc'] = 'Der Nutzername Ihrer alfaview API Zugangsdaten.';
 $string['api_code'] = 'Secret';
 $string['api_code_desc'] = 'Das Passwort Ihrer alfaview API Zugangsdaten.';
 $string['api_company_id'] = 'Account ID';
 $string['api_company_id_desc'] = 'Der Kontoname Ihrer alfaview API Zugangsdaten.';
+$string['connection_status_ok'] = 'Verbindung erfolgreich.';
+$string['connection_status_error'] = 'Verbindung fehlgeschlagen. Überprüfen Sie, ob Sie die richtigen Werte eingegeben haben und ob der Benutzer, der den API-Schlüssel erstellt hat, über Berechtigungen zum Verwalten von Benutzern und Räumen verfügt.';
 
 $string['modulename'] = 'alfaview Klassenraum';
 $string['modulenameplural'] = 'alfaview Klassenräume';

--- a/lang/en/alfaview.php
+++ b/lang/en/alfaview.php
@@ -31,14 +31,14 @@ $string['pluginname'] = 'alfaview';
 $string['settings'] = 'Configuration';
 $string['settings_desc'] = 'Configure alfaview';
 $string['api_description'] = 'API information is available in the alfaview admin app, under <a href="https://app.alfaview.com/#/settings/api-keys" target="_blank">Account Management</a>.';
-$string['api_host'] = 'Host';
-$string['api_host_desc'] = 'The URL of the alfaview API.';
 $string['api_client_id'] = 'Alias (Client ID)';
 $string['api_client_id_desc'] = 'The username of your alfaview API credentials.';
 $string['api_code'] = 'Secret';
 $string['api_code_desc'] = 'The password of your alfaview API credentials.';
 $string['api_company_id'] = 'Account ID';
 $string['api_company_id_desc'] = 'The account identifier of your alfaview API credentials.';
+$string['connection_status_ok'] = 'Connection successful.';
+$string['connection_status_error'] = 'Connection failed, please check that you entered the correct values and that the user who created the API key has permissions to administrate user and rooms.';
 
 $string['modulename'] = 'alfaview classroom';
 $string['modulenameplural'] = 'alfaview classrooms';

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_alfaview';
-$plugin->release = '0.3.1';
-$plugin->version = 2020063000;
+$plugin->release = '0.3.2';
+$plugin->version = 2020092800;
 $plugin->requires = 2018120300;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Updates alfaview-php-sdk to 2.1.0 via composer.
Removes the API Host setting from the plugin settings.
Checks the API credentials on settings page.